### PR TITLE
Added a method to bold | italic the placeholder

### DIFF
--- a/library/src/main/java/com/mancj/materialsearchbar/MaterialSearchBar.java
+++ b/library/src/main/java/com/mancj/materialsearchbar/MaterialSearchBar.java
@@ -292,6 +292,15 @@ public class MaterialSearchBar extends RelativeLayout implements View.OnClickLis
             searchBarCardView.setRadius(getResources().getDimension(R.dimen.corner_radius_default));
         }
     }
+                
+      //A method to bold or italic the placeholder
+    public stylePlaceholder(boolean bold, boolean italic){
+     
+            if(bold)
+                    placeholder.setTypeface(placeholder.getTypeface(), Typeface,BOLD);
+            if(italic)
+                    plcaeholder.setTypeface(placeholder.getTypeface(),Typeface.ITALIC);
+    }
 
     private void setupSearchBarColor() {
         searchBarCardView.setCardBackgroundColor(searchBarColor);

--- a/library/src/main/res/layout/searchbar.xml
+++ b/library/src/main/res/layout/searchbar.xml
@@ -55,7 +55,6 @@
                 android:maxLines="1"
                 android:textAppearance="?android:attr/textAppearanceMedium"
                 android:textColor="@color/searchBarPlaceholderColor"
-                android:textStyle="bold"
                 android:visibility="visible"
                 tools:text="PlaceHolder"/>
 


### PR DESCRIPTION
Earlier the default text style of placeholder was bold, that's fine but I wanted a normal style. I wasn't able to figure out how to change that in my app where I'm using your search bar, so I decided to create a separate method for this. 
I don't know if something is already available or not. If yes! please tell me how to do that. 
Finally thanks for creating this. It's very helpful.